### PR TITLE
Extract PostedBy component for reusable seller links

### DIFF
--- a/frontend/src/components/PostedBy.js
+++ b/frontend/src/components/PostedBy.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Typography, Link } from '@material-ui/core';
+import { useHistory } from 'react-router-dom';
+
+const PostedBy = ({ username, terminalId, maxLength = 30 }) => {
+  const history = useHistory();
+
+  // Helper function to truncate text
+  const truncateText = (text, maxLength) => {
+    if (!text) return '';
+    return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
+  };
+
+  // Handle username click to navigate to user profile
+  const handleUsernameClick = (e) => {
+    e.stopPropagation(); // Prevent triggering any parent click handlers
+    if (terminalId) {
+      history.push(`/profile/${terminalId}`);
+    }
+  };
+
+  // Don't render if no username or terminal_id
+  if (!username || !terminalId) {
+    return null;
+  }
+
+  return (
+    <Typography variant="body2">
+      Posted by: <Link 
+        component="button"
+        variant="body2"
+        onClick={handleUsernameClick}
+      >
+        {truncateText(username, maxLength)}
+      </Link>
+    </Typography>
+  );
+};
+
+export default PostedBy;

--- a/frontend/src/views/searchables/DownloadableSearchableDetails.js
+++ b/frontend/src/views/searchables/DownloadableSearchableDetails.js
@@ -20,6 +20,7 @@ import backend from '../utilities/Backend';
 import { isMockMode } from '../../mocks/mockBackend';
 import ZoomableImage from '../../components/ZoomableImage';
 import RatingDisplay from '../../components/Rating/RatingDisplay';
+import PostedBy from '../../components/PostedBy';
 import useComponentStyles from '../../themes/componentStyles';
 import { mockAccount } from '../../mocks/mockAuth';
 
@@ -643,6 +644,13 @@ const DownloadableSearchableDetails = () => {
               {SearchableItem.payloads.public.title || `Downloads #${SearchableItem.searchable_id}`}
             </Typography>
             <Divider />
+            
+            {/* Posted by section */}
+            <PostedBy 
+              username={SearchableItem.username} 
+              terminalId={SearchableItem.terminal_id} 
+              maxLength={30}
+            />
             
             {!loadingRatings && searchableRating && (
               <Box>

--- a/frontend/src/views/searchables/SearchablesProfile.js
+++ b/frontend/src/views/searchables/SearchablesProfile.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { 
-  Typography, Paper, Box, Divider, Link
+  Typography, Paper, Box, Divider
 } from '@material-ui/core';
-import { useHistory } from 'react-router-dom';
 import useComponentStyles from '../../themes/componentStyles';
+import PostedBy from '../../components/PostedBy';
 const SearchablesProfile = ({ item, onClick }) => {
   const classes = useComponentStyles();
-  const history = useHistory();
 
   // Extract data from the new structure
   const publicData = item.payloads?.public || {};
@@ -16,14 +15,6 @@ const SearchablesProfile = ({ item, onClick }) => {
   const truncateText = (text, maxLength) => {
     if (!text) return '';
     return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text;
-  };
-
-  // Handle username click to navigate to user profile
-  const handleUsernameClick = (e) => {
-    e.stopPropagation(); // Prevent triggering the item click
-    if (item.terminal_id) {
-      history.push(`/profile/${item.terminal_id}`);
-    }
   };
 
   return (
@@ -42,17 +33,11 @@ const SearchablesProfile = ({ item, onClick }) => {
           <Divider />
           
           <Box>
-            {item.username && item.terminal_id && (
-              <Typography variant="body2">
-                Posted by: <Link 
-                  component="button"
-                  variant="body2"
-                  onClick={handleUsernameClick}
-                >
-                  {truncateText(item.username, 30)}
-                </Link>
-              </Typography>
-            )}
+            <PostedBy 
+              username={item.username} 
+              terminalId={item.terminal_id} 
+              maxLength={30}
+            />
             
             {/* Only show price if it's in public payload */}
             {publicData.price && (


### PR DESCRIPTION
- Create independent PostedBy component in frontend/src/components/
- Refactor SearchablesProfile to use new PostedBy component
- Add PostedBy component to DownloadableSearchableDetails
- Maintain existing functionality while improving code reusability

🤖 Generated with [Claude Code](https://claude.ai/code)